### PR TITLE
Add dependency review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,15 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run dependency review
+        uses: actions/dependency-review-action@v4


### PR DESCRIPTION
Fixes #38

Add a new GitHub Action workflow for dependency review.

* Create `.github/workflows/dependency-review.yml` file.
* Set the workflow to run on `pull_request` events.
* Add steps to check out the repository and run the dependency review action using `actions/dependency-review-action@v4`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xebia/github-copilot-updates/pull/39?shareId=5c9ab2c1-0d52-404e-8b92-f284bcfcd56f).