### PR TITLE
group the npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:


### PR DESCRIPTION
This pull request includes a modification to the `.github/dependabot.yml` file to better organize dependencies by type.

Dependency management improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R12-R15): Added a new group for production dependencies to the `updates` section to separate production dependencies from others.