### PR TITLE
Adding a video on MCP servers

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -255,6 +255,14 @@
                   "videoUrl": "https://youtu.be/JtJ3_ATBsTY",
                   "description": "How Agent Mode helps you by iterating over your prompt by itself.",
                   "ghes_support": true
+                },
+                {
+                  
+                  "id": 45,
+                  "title": "MCP with Azure and GitHub",
+                  "videoUrl": "https://youtu.be/m6XBVRXfFN8",
+                  "description": "Empower Agent Mode with extra context and capabilities by supercharging it with MCP servers. See how you can bring in extra information from Azure resources to add extra information to creating GitHub issues",
+                  "ghes_support": true
                 }
               ]
             },


### PR DESCRIPTION
This pull request adds a new entry to the `public/data.json` file to include information about a new video resource. 

* **New video resource added**:
  * A new entry with `id: 45` has been added, titled "MCP with Azure and GitHub." It includes a video URL (`https://youtu.be/m6XBVRXfFN8`) and a description explaining how to use MCP servers to enhance Agent Mode with additional context from Azure resources for creating GitHub issues. The `ghes_support` field is set to `true`. (`[public/data.jsonR258-R265](diffhunk://#diff-e37e3a9264ad80f2d0c18ae3e57737ba5ad9c2a752cd3e93add34ed638f23c04R258-R265)`)